### PR TITLE
Tiny change

### DIFF
--- a/nitime/descriptors.py
+++ b/nitime/descriptors.py
@@ -134,8 +134,9 @@ class OneTimeProperty(object):
            #return func
            return self.getter
 
+       #Errors in the following line are errors in setting a OneTimeProperty:
        val = self.getter(obj)
-       #print "** auto_attr - loading '%s'" % self.name  # dbg
+
        setattr(obj, self.name, val)
        return val
 


### PR DESCRIPTION
When a OneTimeProperty is set and throws an error, the top of the stack is this line in descriptors.py. I added a comment here, which will appear in the top of the stack and might make it easier to understand what went wrong. 
