### PR TITLE
tiny fix to DPSS_windows

### DIFF
--- a/nitime/algorithms.py
+++ b/nitime/algorithms.py
@@ -1594,6 +1594,7 @@ def DPSS_windows(N, NW, Kmax):
     # the main diagonal = ([N-1-2*t]/2)**2 cos(2PIW), t=[0,1,2,...,N-1]
     # and the first off-diangonal = t(N-t)/2, t=[1,2,...,N-1]
     # [see Percival and Walden, 1993]
+    Kmax=int(Kmax)
     W = float(NW)/N
     ab = np.zeros((2,N), 'd')
     nidx = np.arange(N)


### PR DESCRIPTION
DPSS_windows (and specifically linalg.eig_banded) tends to segfault when the Kmax input is not an integer, so I cast it to be an integer, if it isn't
