### PR TITLE
Event slicing

### DIFF
--- a/nitime/tests/test_timeseries.py
+++ b/nitime/tests/test_timeseries.py
@@ -587,5 +587,22 @@ def test_Events():
         yield npt.assert_equal(ev2.index.i0,i0)
         yield npt.assert_equal(ev2.index.i1,i1)
 
+        #make sure slicing works
+        #one_event = ts.Events(t[[0]],time_unit=unit,i=[x[0]],j=[y[0]],k=[z[0]])
+        #regular indexing
+        yield npt.assert_equal(ev1[0].data['i'],x[0])
+        yield npt.assert_equal(ev1[0:2].data['i'],x[0:2])
+        
+        # indexing w/ time
+        yield npt.assert_equal(ev1[0.].data['i'],x[0])
+
+        # indexing w/ epoch
+        ep = ts.Epochs(start=0,stop=1.5, time_unit='ms')
+        print ev1[ep]
+        yield npt.assert_equal(ev1[ep].data['i'],x[0])
+
+        # fancy indexing (w/ boolean mask)
+        yield npt.assert_equal(ev1[ev3.index.trial==0].data['j'],y[0:2])
+
 
     


### PR DESCRIPTION
Allow event slicing/indexing with integers, slices, epochs, and timestamps.

Does not yet implement Event.index and labels transfer.

> > > ev = nitime.timeseries.Events([1,2,3], x=[0,1,2], y=['a','b','c'])
> > > ev[0]
> > > Events:
> > >         TimeArray([ 1.], time_unit='s')
> > >         {'y': array(['a'],
> > >       dtype='|S1'), 'x': array([0])}
> > > 
> > > ev[0:2]
> > > Events:
> > >         TimeArray([ 1.,  2.], time_unit='s')
> > >         {'y': array(['a', 'b'],
> > >       dtype='|S1'), 'x': array([0, 1])}
> > > 
> > > ev[nitime.timeseries.Epochs(start=1,stop=2.5)]
> > > Events:
> > >         TimeArray([ 1.,  2.], time_unit='s')
> > >         {'y': array(['a', 'b'],
> > >       dtype='|S1'), 'x': array([0, 1])}
