### PR TITLE
RF: utils.multi_interesect no longer relies on deprecated intersect1d_nu

### DIFF
--- a/nitime/tests/test_utils.py
+++ b/nitime/tests/test_utils.py
@@ -200,3 +200,14 @@ def test_information_criteria():
     # nt.assert_equal(np.argmin(AIC), 2)
     # nt.assert_equal(np.argmin(AICc), 2)
     nt.assert_equal(np.argmin(BIC), 2)
+
+
+def test_multi_intersect():
+    """
+    Testing the multi-intersect utility function
+    """
+
+    arr1 = np.array(np.arange(1000).reshape(2,500))
+    arr2 = np.array([[1,0.1,0.2],[0.3,0.4, 0.5]])
+    arr3 = np.array(1)
+    npt.assert_equal(1, utils.multi_intersect([arr1, arr2, arr3]))

--- a/nitime/utils.py
+++ b/nitime/utils.py
@@ -955,16 +955,13 @@ def multi_intersect(input):
 
     Notes
     -----
-    Simply runs intersect1d_nu iteratively on the inputs
+    Simply runs intersect1d iteratively on the inputs
     """
-    output = np.intersect1d_nu(input[0], input[1])
+    arr  = input[0].ravel()
+    for this in input[1:]:
+        arr = np.intersect1d(arr, this.ravel())
 
-    for i in input:
-
-        output = np.intersect1d_nu(output, i)
-
-    return output
-
+    return arr
 
 def zero_pad(time_series, NFFT):
     """Pad a time-series with zeros on either side, depending on its length"""


### PR DESCRIPTION
This deals with #97. 

I am still getting this error in the tests: 
# 
## ERROR: nitime.tests.test_lazy.test_lazy_reload

Traceback (most recent call last):
  File "/Library/Frameworks/EPD64.framework/Versions/7.1/lib/python2.7/site-packages/nose/case.py", line 187, in runTest
    self.test(*self.arg)
  File "/Library/Frameworks/EPD64.framework/Versions/7.1/lib/python2.7/site-packages/numpy/testing/decorators.py", line 213, in knownfailer
    raise KnownFailureTest, msg
KnownFailureTest: Reloading a module is a silent no-op

---

@ivanov: is that meant to raise an error like that? 
