### PR TITLE
FIX: Fix interpolation of dpss_windows

### DIFF
--- a/nitime/algorithms/spectral.py
+++ b/nitime/algorithms/spectral.py
@@ -419,8 +419,7 @@ def dpss_windows(N, NW, Kmax, interp_from=None, interp_kind='linear'):
         for this_d in d:
             x = np.arange(this_d.shape[-1])
             I = interpolate.interp1d(x, this_d, kind=interp_kind)
-            d_temp = I(np.arange(0, this_d.shape[-1] - 1,
-                                 float(this_d.shape[-1] - 1) / N))
+            d_temp = I(np.linspace(0, this_d.shape[-1] - 1, N, endpoint=False))
 
             # Rescale:
             d_temp = d_temp / np.sqrt(np.sum(d_temp ** 2))

--- a/nitime/algorithms/tests/test_spectral.py
+++ b/nitime/algorithms/tests/test_spectral.py
@@ -157,7 +157,7 @@ def test_periodogram_csd():
 
 
 def test_dpss_windows():
-    """ Test a funky corner case of DPSS_windows """
+    """ Test a couple of funky corner cases of DPSS_windows """
 
     N = 1024
     NW = 0  # Setting NW to 0 triggers the weird corner case in which some of
@@ -168,6 +168,11 @@ def test_dpss_windows():
     d, w = tsa.dpss_windows(1024, 0, 7)
     for this_d in d[0::2]:
         npt.assert_equal(this_d.sum(axis=-1) < 0, False)
+
+    # Make sure we interpolate to the proper number of points
+    d, w = tsa.dpss_windows(245411, 4, 8, 1000)
+    npt.assert_equal(d.shape[-1], 245411)
+
 
 def test_dpss_properties():
     """ Test conventions of Slepian eigenvectors """


### PR DESCRIPTION
Interpolation was done unsafely before using floating point comparisons, see:
```Python
>>> N_from, N_to = 1000, 245411
>>> d_temp = np.arange(0, N_from - 1, float(N_from - 1) / N_to)  # old way
>>> print(d_temp.shape)
(245412,)
>>> print(d_temp[:3])
[ 0.          0.00407072  0.00814144]
>>> print(d_temp[-3:])
[ 998.99185856  998.99592928  999.        ]
>>> d_temp = np.linspace(0, N_from - 1, N_to, endpoint=False)  # new way
>>> print(d_temp.shape)
(245411,)
>>> print(d_temp[:3])
[ 0.          0.00407072  0.00814144]
>>> print(d_temp[-2:])
[ 998.99185856  998.99592928]
```