### PR TITLE
GrangerAnalyzer's causality_xy[i, j] should represent the causality i => j

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ deploy:
     repo: nipy/nitime
 python:
 - 2.7
-- 3.3
 - 3.4
 - 3.5
 env:

--- a/nitime/analysis/granger.py
+++ b/nitime/analysis/granger.py
@@ -196,7 +196,7 @@ class GrangerAnalyzer(BaseAnalyzer):
 
         # 'Translate' from dict form into matrix form:
         for i, j in self.ij:
-            arr[j, i, :] = self._granger_causality[key][i, j]
+            arr[i, j, :] = self._granger_causality[key][i, j]
         return arr
 
     @desc.setattr_on_read

--- a/nitime/analysis/tests/test_granger.py
+++ b/nitime/analysis/tests/test_granger.py
@@ -109,5 +109,10 @@ def test_GrangerAnalyzer():
     # Test inputting ij:
     g2 = gc.GrangerAnalyzer(ts1, ij=[(0, 1), (1, 0)])
 
+    # g1 agrees with g2
+    npt.assert_almost_equal(g1.causality_xy[0, 1], g2.causality_xy[0, 1])
+    npt.assert_almost_equal(g1.causality_yx[0, 1], g2.causality_yx[0, 1])
+
     # x => y for one is like y => x for the other:
-    npt.assert_almost_equal(g1.causality_yx[1, 0], g2.causality_xy[0, 1])
+    npt.assert_almost_equal(g2.causality_yx[1, 0], g2.causality_xy[0, 1])
+    npt.assert_almost_equal(g2.causality_xy[1, 0], g2.causality_yx[0, 1])


### PR DESCRIPTION
I wonder why the indexing of GrangerAnalyzer's causality_xy are opposite against the given order.
Having seen commits 528be342fedcd134c08ccb1654140621a157ba0e and e3cfd0d66bb667f600ec52709247782d02b62a65, it is still puzzling.