### PR TITLE
Drop dep on pytest version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 sphinx
-pytest==3.6.1
+pytest
 pytest-cov
 nibabel
 networkx


### PR DESCRIPTION
pytest version being set to 3.6.1 is causing incompatibilities - 
I've tested this with my own master branch and the result is available [here](https://travis-ci.org/github/nileshpatra/nitime/builds/717040239). The test passing earlier with the exact same commit fails.

This is an attempt to fix the CI-tests.
The CI again goes green my changed, results available [here](https://travis-ci.org/github/nileshpatra/nitime/builds/717041751)