### PR TITLE
fixing Frequency::__repr__() recursion in Python3

### DIFF
--- a/nitime/timeseries.py
+++ b/nitime/timeseries.py
@@ -902,7 +902,8 @@ class Frequency(float):
 
     def __repr__(self):
 
-        return str(self) + ' Hz'
+        return str(float(self)) + ' Hz'
+
 
     def to_period(self, time_unit=base_unit):
         """Convert the value of a frequency to the corresponding period


### PR DESCRIPTION
Hi and thank you for such a great library!

Apparently running the tutorial from http://nipy.org/nitime/users/tutorial.html works for Python2, but in Python 3.8 runs into recursion at `In [5]` ( printing the sampling rate ) -- see a traceback below.

I'm not sure whether this would be the best way to fix this, but it kinda works.

Best regards, S-V

PS. Traceback :
```
In [5]: t1.sampling_rate                                                                                  
Out[5]: ---------------------------------------------------------------------------
RecursionError                            Traceback (most recent call last)
/usr/lib/python3/dist-packages/IPython/core/formatters.py in __call__(self, obj)
    700                 type_pprinters=self.type_printers,
    701                 deferred_pprinters=self.deferred_printers)
--> 702             printer.pretty(obj)
    703             printer.flush()
    704             return stream.getvalue()

/usr/lib/python3/dist-packages/IPython/lib/pretty.py in pretty(self, obj)
    392                         if cls is not object \
    393                                 and callable(cls.__dict__.get('__repr__')):
--> 394                             return _repr_pprint(obj, self, cycle)
    395
    396             return _default_pprint(obj, self, cycle)

/usr/lib/python3/dist-packages/IPython/lib/pretty.py in _repr_pprint(obj, p, cycle)
    682     """A pprint that just redirects to the normal repr function."""
    683     # Find newlines and replace them with p.break_()
--> 684     output = repr(obj)
    685     lines = output.splitlines()
    686     with p.group():

/usr/local/lib/python3.8/dist-packages/nitime/timeseries.py in __repr__(self)
    910
    911         # return str(self) + ' Hz'
--> 912         return self.__str__()
    913
    914

/usr/local/lib/python3.8/dist-packages/nitime/timeseries.py in __str__(self)
    905     def __str__(self):
    906
--> 907         return str(self)
    908
    909     def __repr__(self):

... last 1 frames repeated, from the frame below ...

/usr/local/lib/python3.8/dist-packages/nitime/timeseries.py in __str__(self)
    905     def __str__(self):
    906
--> 907         return str(self)
    908
    909     def __repr__(self):

RecursionError: maximum recursion depth exceeded while getting the str of an object
```
