### PR TITLE
fix wrong weight index in MTCoherenceAnalyzer.coherence()

### DIFF
--- a/nitime/analysis/coherence.py
+++ b/nitime/analysis/coherence.py
@@ -351,7 +351,7 @@ class MTCoherenceAnalyzer(BaseAnalyzer):
                                              self.weights[i],
                                              sides='onesided')
                 syy = tsa.mtm_cross_spectrum(self.spectra[j], self.spectra[j],
-                                             self.weights[i],
+                                             self.weights[j],
                                              sides='onesided')
                 psd_mat[0, i, j] = sxx
                 psd_mat[1, i, j] = syy


### PR DESCRIPTION
When computing the PSD of series y, the function was using the index `i`
to get weights:

```
syy = tsa.mtm_cross_spectrum(self.spectra[j], self.spectra[j],
			     self.weights[i],
			     sides='onesided')
```

while it should be using `self.weights[j]`.