### PR TITLE
fix all nans in GrangerAnalyzer

### DIFF
--- a/doc/examples/multi_taper_coh.py
+++ b/doc/examples/multi_taper_coh.py
@@ -152,7 +152,7 @@ Looping over the ROIs:
 """
 
 for i in range(nseq):
-    for j in range(i):
+    for j in range(i, nseq):
 
         """
 

--- a/nitime/analysis/granger.py
+++ b/nitime/analysis/granger.py
@@ -108,10 +108,8 @@ class GrangerAnalyzer(BaseAnalyzer):
             # non-same i's and j's:
             x, y = np.meshgrid(np.arange(self._n_process),
                                np.arange(self._n_process))
-            # index into the **lower** triangle. Then the element (i,j) stores
-            # the causality from x to y, e.g. gc['gc_xy'][i, j] = f_x2y
-            self.ij = list(zip(y[tril_indices_from(y, -1)],
-                          x[tril_indices_from(x, -1)]))
+            self.ij = list(zip(x[tril_indices_from(x, -1)],
+                          y[tril_indices_from(y, -1)]))
         else:
             self.ij = ij
 

--- a/nitime/analysis/granger.py
+++ b/nitime/analysis/granger.py
@@ -108,8 +108,10 @@ class GrangerAnalyzer(BaseAnalyzer):
             # non-same i's and j's:
             x, y = np.meshgrid(np.arange(self._n_process),
                                np.arange(self._n_process))
-            self.ij = list(zip(x[tril_indices_from(x, -1)],
-                          y[tril_indices_from(y, -1)]))
+            # index into the **lower** triangle. Then the element (i,j) stores
+            # the causality from x to y, e.g. gc['gc_xy'][i, j] = f_x2y
+            self.ij = list(zip(y[tril_indices_from(y, -1)],
+                          x[tril_indices_from(x, -1)]))
         else:
             self.ij = ij
 

--- a/nitime/viz.py
+++ b/nitime/viz.py
@@ -30,7 +30,7 @@ if matplotlib.__version__[:3] == '1.3' or matplotlib.__version__[:3] == '1.4':
     import matplotlib.axis as ax
     ax.munits = mpl_units
 
-from nitime.utils import triu_indices
+from nitime.utils import tril_indices
 
 #Some visualization functions require networkx. Import that if possible:
 try:
@@ -272,10 +272,12 @@ def drawmatrix_channels(in_m, channel_names=None, fig=None, x_tick_rot=0,
     # data provided
     m = in_m.copy()
 
-    # Null the upper triangle, so that you don't get the redundant and the
+    # Null the **lower** triangle, so that you don't get the redundant and the
     # diagonal values:
-    idx_null = triu_indices(m.shape[0])
+    idx_null = tril_indices(m.shape[0])
     m[idx_null] = np.nan
+    # tranpose the upper triangle to lower
+    m = m.T
 
     # Extract the minimum and maximum values for scaling of the
     # colormap/colorbar:


### PR DESCRIPTION
This is to fix the issue nipy#173.

`GrangerAnalyzer` put its outputs in the upper triangle only, which
would be removed by `drawmatrix_channels()` which takes only the lower
triangle, creating an array of all nans.

This fix changes the `drawmatrix_channels()` to let it take the upper
triangle instead, then transpose the matrix before plotting.

Another possible fix is to transposes outputs of `GrangerAnalyzer` into the
lower triangle. However this would break with the old behavior including
failing unit tests (`test_granger.py`).

Another reason to change the `drawmatrix_channels()` instead is that
other similar functions, including `CorrelationAnalyzer.xcorr`,
`CoherenceAnalyzer.coherence` all computes the upper triangle first,
then transpose to fill the lower, e.g.

```
idx = tril_indices(tseries_length, -1)
xcorr[idx[0], idx[1], ...] = xcorr[idx[1], idx[0], ...]
```

But granger is a bit different in that it is not symmetrical so we don't
just mirror the upper triangle into the low.

Another reason to keep the upper triangle in granger is that the
indices of pairs argument (`ij`) of the `GrangerAnalyzer.__init__()`
translates more naturally to the upper triangle indices, e.g. pair
`(0, 1)` -> (row-0, column-1),
`(2, 4)` -> (row-2, column-4).
If feels more intuitive (to me at least) to preserve this, rather than doing a
transpose here. This also helps pass the `test_granger.py` unit test.

Related changes needed:

in `doc/examples/multi_taper_coh.py`, I have to change the nested `for` loop
so the results are put into the upper triangle. The old `for` loop:

```
for i in range(nseq):
    for j in range(i):
```

New:

```
for i in range(nseq):
    for j in range(i, nseq):
```

This is also consistent with `CoherenceAnalyzer` etc..

I've tested all scripts in the `doc/examples` folder that involve the
`drawmatrix_channels()` function. All figures look good.