### PR TITLE
use np.fft.rfftfreq to get 1-sided periodogram freqs

### DIFF
--- a/nitime/algorithms/spectral.py
+++ b/nitime/algorithms/spectral.py
@@ -249,7 +249,8 @@ def periodogram(s, Fs=2 * np.pi, Sk=None, N=None,
         Fl = (N + 1) // 2
         pshape[-1] = Fn
         P = np.zeros(pshape, 'd')
-        freqs = np.linspace(0, Fs // 2, Fn)
+        #freqs = np.linspace(0, Fs // 2, Fn)
+        freqs = np.fft.rfftfreq(N)
         P[..., 0] = (Sk[..., 0] * Sk[..., 0].conj()).real
         P[..., 1:Fl] = 2 * (Sk[..., 1:Fl] * Sk[..., 1:Fl].conj()).real
         if Fn > Fl:

--- a/nitime/algorithms/spectral.py
+++ b/nitime/algorithms/spectral.py
@@ -250,7 +250,7 @@ def periodogram(s, Fs=2 * np.pi, Sk=None, N=None,
         pshape[-1] = Fn
         P = np.zeros(pshape, 'd')
         #freqs = np.linspace(0, Fs // 2, Fn)
-        freqs = np.fft.rfftfreq(N)
+        freqs = np.fft.rfftfreq(N) * Fs
         P[..., 0] = (Sk[..., 0] * Sk[..., 0].conj()).real
         P[..., 1:Fl] = 2 * (Sk[..., 1:Fl] * Sk[..., 1:Fl].conj()).real
         if Fn > Fl:


### PR DESCRIPTION
This is to fix issue https://github.com/nipy/nitime/issues/191

Also noticed that `np.fft.rfftfreq(N)` gives different results as
`scipy.fftpack.rfftfreq(N`). The former gives the correct positive freqs.