### PR TITLE
ENH: Build wheels on GitHub actions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,6 +15,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  job_metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      commit_message: ${{ steps.get_commit_message.outputs.commit_message }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Print head git commit message
+        id: get_commit_message
+        run: |
+          if [[ -z "$COMMIT_MSG" ]]; then
+            COMMIT_MSG=$(git show -s --format=%s $REF)
+          fi
+          echo commit_message=$COMMIT_MSG | tee -a $GITHUB_OUTPUT
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          REF: ${{ github.event.pull_request.head.sha }}
+
   build-sdist:
     name: Build sdist
     runs-on: ubuntu-latest
@@ -29,8 +49,9 @@ jobs:
 
   build-wheel:
     name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+    needs: [job_metadata]
     runs-on: ${{ matrix.buildplat[0] }}
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, '[build wheels]')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') || contains(needs.job_metadata.outputs.commit_message, '[build wheels]')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -84,7 +84,29 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: dist/
-      - run: ls -lR
-      - run: mv dist/*/*.{tar.gz,whl} dist
-      - run: rmdir dist/*/
-      - run: ls -lR
+      - name: Check artifacts
+        run: ls -lR
+      - name: Consolidate and re-check
+        run: |
+          mv dist/*/*.{tar.gz,whl} dist
+          rmdir dist/*/
+          ls -lR
+      - run: pipx run twine dist/*
+
+  publish:
+    runs-on: ubuntu-latest
+    environment: "Package deployment"
+    needs: [pre-publish]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: dist/
+      - name: Consolidate artifacts
+        run: |
+          mv dist/*/*.{tar.gz,whl} dist
+          rmdir dist/*/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,3 +52,25 @@ jobs:
         with:
           name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
+
+  test-sdist:
+    name: Test sdist
+    needs: [build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdist
+          path: ./dist
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install sdist
+        run: pip install dist/*.tar.gz
+      - run: python -c 'import nitime; print(nitime.__version__)'
+      - name: Install pytest
+        run: pip install pytest
+      - name: Run tests
+        run: pytest -v --pyargs nitime

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,6 +30,7 @@ jobs:
   build-wheel:
     name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }}
     runs-on: ${{ matrix.buildplat[0] }}
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, '[build wheels]')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-11]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        run: pipx run cibuildwheel
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -113,7 +113,7 @@ jobs:
           mv dist/*/*.{tar.gz,whl} dist
           rmdir dist/*/
           ls -lR
-      - run: pipx run twine dist/*
+      - run: pipx run twine check dist/*
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,19 +15,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build sdist
+        run: pipx run build -s
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sdist
+          path: ./dist/*.tar.gz
+
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+    runs-on: ${{ matrix.buildplat[0] }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11]
+        buildplat:
+          - [ubuntu-20.04, manylinux_x86_64]
+          - [ubuntu-20.04, musllinux_x86_64]
+          - [macos-12, macosx_*]
+          - [windows-2019, win_amd64]
+        python: ["cp37", "cp38", "cp39", "cp310", "cp311"]
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Build wheels
         run: pipx run cibuildwheel
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
       - uses: actions/upload-artifact@v3
         with:
+          name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,7 +62,7 @@ jobs:
         python: ["cp37", "cp38", "cp39", "cp310", "cp311"]
         include:
           # Manylinux builds are cheap, do all in one
-          - {buildplat: ["ubuntu-20.04", "manylinux_x86_64"], python: "*"}
+          - { buildplat: ["ubuntu-20.04", "manylinux_x86_64"], python: "*" }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_sdist:
+  build-sdist:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
@@ -27,35 +27,37 @@ jobs:
           name: sdist
           path: ./dist/*.tar.gz
 
-  build_wheels:
+  build-wheel:
     name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }}
     runs-on: ${{ matrix.buildplat[0] }}
     strategy:
       fail-fast: false
       matrix:
         buildplat:
-          - [ubuntu-20.04, manylinux_x86_64]
           - [ubuntu-20.04, musllinux_x86_64]
           - [macos-12, macosx_*]
           - [windows-2019, win_amd64]
         python: ["cp37", "cp38", "cp39", "cp310", "cp311"]
+        include:
+          # Manylinux builds are cheap, do all in one
+          - {buildplat: ["ubuntu-20.04", "manylinux_x86_64"], python: "*"}
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build wheels
+      - name: Build wheel(s)
         run: pipx run cibuildwheel
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
+          name: ${{ matrix.python == '*' && 'all' || matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
 
   test-sdist:
     name: Test sdist
-    needs: [build_sdist]
+    needs: [build-sdist]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3
@@ -74,3 +76,15 @@ jobs:
         run: pip install pytest
       - name: Run tests
         run: pytest -v --pyargs nitime
+
+  pre-publish:
+    runs-on: ubuntu-latest
+    needs: [test-sdist, build-wheel]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: dist/
+      - run: ls -lR
+      - run: mv dist/*/*.{tar.gz,whl} dist
+      - run: rmdir dist/*/
+      - run: ls -lR

--- a/nitime/version.py
+++ b/nitime/version.py
@@ -96,4 +96,4 @@ MICRO = _version_micro
 VERSION = __version__
 PACKAGE_DATA = {"nitime": ["LICENSE", "tests/*.txt", "tests/*.npy",
                            "data/*.nii.gz", "data/*.txt", "data/*.csv"]}
-PYTHON_REQUIRES = ">=3.5"
+PYTHON_REQUIRES = ">=3.7"

--- a/nitime/viz.py
+++ b/nitime/viz.py
@@ -680,7 +680,7 @@ def draw_graph(G,
 
     # Build a 'weighted degree' array obtained by adding the (absolute value)
     # of the weights for all edges pointing to each node:
-    amat = nx.adj_matrix(G).A  # get a normal array out of it
+    amat = nx.adjacency_matrix(G).todense()  # get a normal array out of it
     degarr = abs(amat).sum(0)  # weights are sums across rows
 
     # Map the degree to the 0-1 range so we can use it for sizing the nodes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,5 @@ requires-python = ">=3.7"
 
 [tool.cibuildwheel]
 skip = "pp*"
+
+archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
   "setuptools",
   "cython",
-  "numpy==1.21",  # NEP29 minimum supported numpy as of Jan 31, 2023
+  "numpy==1.21; python_version > '3.6'",  # NEP29 minimum supported numpy as of Jan 31, 2023
+  "numpy==1.19; python_version <= '3.6'",  # cibuildwheel wants to build for Python 3.6 still
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+  "setuptools",
+  "cython",
+  "numpy==1.21",  # NEP29 minimum supported numpy as of Jan 31, 2023
+]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,11 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[project]
-requires-python = ">=3.7"
-
 [tool.cibuildwheel]
-skip = "pp*"
+# Disable CPython 3.6 here; if project.requires-python gets defined,
+# cp36* can be removed
+skip = "pp* cp36*"
 
+# 64-bit builds only; 32-bit builds seem pretty niche these days, so
+# don't bother unless someone asks
 archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,16 @@
 requires = [
   "setuptools",
   "cython",
-  "numpy==1.21; python_version > '3.6'",  # NEP29 minimum supported numpy as of Jan 31, 2023
-  "numpy==1.19; python_version <= '3.6'",  # cibuildwheel wants to build for Python 3.6 still
+  # Newer than NEP29-minimum: compile against oldest numpy available
+  "numpy==1.24; python_version >= '3.11'",
+  "numpy==1.22; python_version >= '3.10' and python_version < '3.11'",
+  # NEP29-minimum as of Jan 31, 2023
+  "numpy==1.21; python_version >= '3.7' and python_version < '3.10'",
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+requires-python = ">=3.7"
+
+[tool.cibuildwheel]
+skip = "pp*"

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ import sys
 if os.path.exists('MANIFEST'):
     os.remove('MANIFEST')
 
-from setuptools import find_packages
-from distutils.core import setup
+from setuptools import find_packages, setup
 
 # Get version and release info, which is all stored in nitime/version.py
 ver_file = os.path.join('nitime', 'version.py')
@@ -49,14 +48,13 @@ opts = dict(name=NAME,
             )
 
 try:
-    from distutils.extension import Extension
-    from Cython.Distutils import build_ext as build_pyx_ext
+    from setuptools import Extension
+    from Cython.Build import cythonize
     from numpy import get_include
     # add Cython extensions to the setup options
     exts = [Extension('nitime._utils', ['nitime/_utils.pyx'],
                       include_dirs=[get_include()])]
-    opts['cmdclass'] = dict(build_ext=build_pyx_ext)
-    opts['ext_modules'] = exts
+    opts['ext_modules'] = cythonize(exts, language_level='3')
 except ImportError:
     # no loop for you!
     pass


### PR DESCRIPTION
* Sets minimum Python to 3.7 (3.6 is EOL)
* Updates the cython configuration based on recent docs
* Drops distutils in favor of setuptools, as distutils will disappear with upcoming Python 3.12
* Adds a `pyproject.toml` to declare build dependencies and configure cibuildwheel
* Runs cibuildwheel on GitHub actions