### PR TITLE
FIX: Address deprecation warnings

### DIFF
--- a/nitime/algorithms/spectral.py
+++ b/nitime/algorithms/spectral.py
@@ -523,7 +523,7 @@ def multi_taper_psd(
     """
     # have last axis be time series for now
     N = s.shape[-1]
-    M = int(np.product(s.shape[:-1]))
+    M = int(np.prod(s.shape[:-1]))
 
     if BW is not None:
         # BW wins in a contest (since it was the original implementation)
@@ -663,7 +663,7 @@ def multi_taper_csd(s, Fs=2 * np.pi, NW=None, BW=None, low_bias=True,
     """
     # have last axis be time series for now
     N = s.shape[-1]
-    M = int(np.product(s.shape[:-1]))
+    M = int(np.prod(s.shape[:-1]))
 
     if BW is not None:
         # BW wins in a contest (since it was the original implementation)

--- a/nitime/algorithms/tests/test_coherence.py
+++ b/nitime/algorithms/tests/test_coherence.py
@@ -8,7 +8,7 @@ import warnings
 
 import numpy as np
 import numpy.testing as npt
-from scipy.signal import signaltools
+from scipy import signal
 import pytest
 
 import matplotlib
@@ -239,7 +239,7 @@ def test_coherence_linear_dependence():
               "Fs": 2 * np.pi}
 
     f, c = tsa.coherence(np.vstack([x, y]), csd_method=method)
-    c_t = np.abs(signaltools.resample(c_t, c.shape[-1]))
+    c_t = np.abs(signal.resample(c_t, c.shape[-1]))
 
     npt.assert_array_almost_equal(c[0, 1], c_t, 2)
 

--- a/nitime/algorithms/tests/test_coherence.py
+++ b/nitime/algorithms/tests/test_coherence.py
@@ -203,7 +203,7 @@ def test_correlation_spectrum():
 # XXX FIXME: http://github.com/nipy/nitime/issues/issue/1
 @pytest.mark.skipif(True, reason="http://github.com/nipy/nitime/issues/issue/1")
 def test_coherence_linear_dependence():
-    """
+    r"""
     Tests that the coherence between two linearly dependent time-series
     behaves as expected.
 

--- a/nitime/algorithms/tests/test_spectral.py
+++ b/nitime/algorithms/tests/test_spectral.py
@@ -70,12 +70,12 @@ def test_get_spectra_complex():
         r, _, _ = utils.ar_generator(N=2 ** 16)  # It needs to be that long for
                                                  # the answers to converge
         c, _, _ = utils.ar_generator(N=2 ** 16)
-        arsig1 = r + c * scipy.sqrt(-1)
+        arsig1 = r + c * 1j
 
         r, _, _ = utils.ar_generator(N=2 ** 16)
         c, _, _ = utils.ar_generator(N=2 ** 16)
 
-        arsig2 = r + c * scipy.sqrt(-1)
+        arsig2 = r + c * 1j
         avg_pwr1.append((arsig1 * arsig1.conjugate()).mean())
         avg_pwr2.append((arsig2 * arsig2.conjugate()).mean())
 
@@ -118,7 +118,7 @@ def test_periodogram():
     N = 1024
     r, _, _ = utils.ar_generator(N=N)
     c, _, _ = utils.ar_generator(N=N)
-    arsig = r + c * scipy.sqrt(-1)
+    arsig = r + c * 1j
 
     f, c = tsa.periodogram(arsig)
     npt.assert_equal(f.shape[0], N)  # Should be N, not the one-sided N/2 + 1
@@ -143,11 +143,11 @@ def test_periodogram_csd():
     N = 1024
     r, _, _ = utils.ar_generator(N=N)
     c, _, _ = utils.ar_generator(N=N)
-    arsig1 = r + c * scipy.sqrt(-1)
+    arsig1 = r + c * 1j
 
     r, _, _ = utils.ar_generator(N=N)
     c, _, _ = utils.ar_generator(N=N)
-    arsig2 = r + c * scipy.sqrt(-1)
+    arsig2 = r + c * 1j
 
     tseries = np.vstack([arsig1, arsig2])
 

--- a/nitime/tests/test_algorithms.py
+++ b/nitime/tests/test_algorithms.py
@@ -3,8 +3,7 @@ import os
 import numpy as np
 import numpy.testing as npt
 
-from scipy.signal import signaltools
-from scipy import fftpack
+from scipy import fftpack, signal
 
 import nitime
 from nitime import algorithms as tsa
@@ -24,16 +23,16 @@ def test_scipy_resample():
          for f in freq_list]
     tst = np.array(a).sum(axis=0)
     # interpolate to 128 Hz sampling
-    t_up = signaltools.resample(tst, 128)
+    t_up = signal.resample(tst, 128)
     np.testing.assert_array_almost_equal(t_up[::2], tst)
     # downsample to 32 Hz
-    t_dn = signaltools.resample(tst, 32)
+    t_dn = signal.resample(tst, 32)
     np.testing.assert_array_almost_equal(t_dn, tst[::2])
 
     # downsample to 48 Hz, and compute the sampling analytically for comparison
     dn_samp_ana = np.array([np.sin(2 * np.pi * f * np.linspace(0, 1, 48, endpoint=False))
                             for f in freq_list]).sum(axis=0)
-    t_dn2 = signaltools.resample(tst, 48)
+    t_dn2 = signal.resample(tst, 48)
     npt.assert_array_almost_equal(t_dn2, dn_samp_ana)
 
 

--- a/nitime/tests/test_lazy.py
+++ b/nitime/tests/test_lazy.py
@@ -37,6 +37,6 @@ def test_lazy_noreload():
         with pytest.raises(ImportError) as e_info:
             reload(mod)
     elif major == 3:
-        import imp
+        import importlib
         with pytest.raises(ImportError) as e_info:
-            imp.reload(mod)
+            importlib.reload(mod)

--- a/nitime/utils.py
+++ b/nitime/utils.py
@@ -730,9 +730,8 @@ def tapered_spectra(s, tapers, NFFT=None, low_bias=True):
     if NFFT is None or NFFT < N:
         NFFT = N
     rest_of_dims = s.shape[:-1]
-    M = int(np.product(rest_of_dims))
 
-    s = s.reshape(int(np.product(rest_of_dims)), N)
+    s = s.reshape(-1, N)
     # de-mean this sucker
     s = remove_bias(s, axis=-1)
 
@@ -1193,7 +1192,7 @@ def fftconvolve(in1, in2, mode="full", axis=None):
     if mode == "full":
         return ret
     elif mode == "same":
-        if np.product(s1, axis=0) > np.product(s2, axis=0):
+        if np.prod(s1, axis=0) > np.prod(s2, axis=0):
             osize = s1
         else:
             osize = s2


### PR DESCRIPTION
`imp` is going to be removed in Python 3.12, so it's time to attend to deprecations. I went through those listed in https://github.com/nipy/nitime/actions/runs/5886802644/job/15965221215. I think I got most.