### PR TITLE
FIX: test_viz.py regression with networkx 2.8.8

### DIFF
--- a/nitime/viz.py
+++ b/nitime/viz.py
@@ -680,7 +680,7 @@ def draw_graph(G,
 
     # Build a 'weighted degree' array obtained by adding the (absolute value)
     # of the weights for all edges pointing to each node:
-    amat = nx.adjacency_matrix(G).todense()  # get a normal array out of it
+    amat = nx.to_numpy_array(G)  # get a normal array out of it
     degarr = abs(amat).sum(0)  # weights are sums across rows
 
     # Map the degree to the 0-1 range so we can use it for sizing the nodes.


### PR DESCRIPTION
As seen in nitime github issue #207, fixing the deprecation of adj_matrix with adjacency_matrix in networkx 3.0 caused a regression in test_viz.py when running with the slightly older networkx 2.8.8.

Per Chris' suggestion, this patch abandons the approach of using adjacent matrix methods for the more generic to_numpy_array, which works unchanged for both networks 2.8.8 and 3.0 onwards.

Thanks: Nilesh Patra and Chris Markiewicz