### PR TITLE
MNT: Update dependencies for 3.12-compatible release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
   "setuptools",
   "setuptools_scm[toml]>=6.2",
   "cython",
-  "numpy==1.26b1; python_version >= '3.12rc1'",  # Until 3.12 and 1.26 are released
   # As of numpy 1.25, you can now build against older APIs.
   # https://numpy.org/doc/stable/release/1.25.0-notes.html
   "numpy>=1.25; python_version > '3.8'",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@
 --only-binary numpy,scipy
 --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 matplotlib>=3.5
-numpy>=1.26.0b1; python_version > '3.11'
-numpy>=1.22; python_version <= '3.11'
+numpy>=1.22
 scipy>=1.8
 networkx>=2.7
 nibabel>=4.0


### PR DESCRIPTION
Very small changes, now that Python 3.12 and numpy 1.26 are out.

Assuming this passes, should be good to merge and release.