### PR TITLE
MNT: Build wheels with limited API

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,13 +58,11 @@ jobs:
       fail-fast: false
       matrix:
         buildplat:
+          - [ubuntu-20.04, manylinux_x86_64]
           - [ubuntu-20.04, musllinux_x86_64]
           - [macos-12, macosx_*]
           - [windows-2019, win_amd64]
-        python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
-        include:
-          # Manylinux builds are cheap, do all in one
-          - { buildplat: ["ubuntu-20.04", "manylinux_x86_64"], python: "*" }
+        python: ["cp312"]
 
     steps:
       - uses: actions/checkout@v3
@@ -108,9 +106,38 @@ jobs:
       - name: Run tests
         run: pytest -v --pyargs nitime
 
+  test-wheel:
+    name: Test wheel
+    needs: [build-wheel]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: dist/
+      - name: Consolidate and list wheels
+        run: |
+          mkdir wheelhouse
+          mv dist/*/*.whl wheelhouse
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install wheel
+        run: pip install --find-links ./wheelhouse --pre nitime
+      - run: python -c 'import nitime; print(nitime.__version__)'
+      - name: Install pytest
+        run: pip install pytest
+      - name: Run tests
+        run: pytest -v --pyargs nitime
+
   pre-publish:
     runs-on: ubuntu-latest
-    needs: [test-sdist, build-wheel]
+    needs: [test-sdist, test-wheel]
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
   "setuptools",
+  "wheel",
   "setuptools_scm[toml]>=6.2",
   "cython",
   # As of numpy 1.25, you can now build against older APIs.


### PR DESCRIPTION
Inspired by @vstinner's [PyCon slides](https://github.com/vstinner/talks/blob/main/2023-CoreDevSprint-Brno/c-api.pdf), I wanted to see if we could build to the Python limited API, which allows a single wheel to support all versions of Python above some minimum.

I've collapsed the build matrix down, and added a broad test matrix to ensure that the built wheels work correctly. This will produce fewer wheels (one per-platform) that should be installable on Python 3.13 as soon as Numpy has a build out.

Once this is in, I can stop pestering you with updates to the build system.

I'm using https://github.com/joerick/python-abi3-package-sample/ as a guide.