### PR TITLE
doc/conf.py: fix after move to nitime/_version.py.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,12 +94,12 @@ copyright = u'2009, Neuroimaging in Python team'
 # We read the version info from the source file.
 ver = {}
 
-ver_file = os.path.join('..', 'nitime', 'version.py')
+ver_file = os.path.join('..', 'nitime', '_version.py')
 with open(ver_file) as f:
     exec(f.read())
 
 # The short X.Y version.
-version = '%s.%s' % (_version_major, _version_minor)
+version = '%s.%s' % (version_tuple[0], version_tuple[1])
 # The full version, including alpha/beta/rc tags.
 release = __version__
 


### PR DESCRIPTION
Since introduction of nitime/_version.py through the move to pyproject.toml, the sphinx documentation configuration script does not seem to have followed.  Use of the former variables are causing a variety of errors when trying to rebuild the documentation.  Adjusting to the new set of variables from nitime/_version.py fixes that.