### PR TITLE
tridisolve not accesible

### DIFF
--- a/nitime/utils.py
+++ b/nitime/utils.py
@@ -881,7 +881,7 @@ def detect_lines(s, tapers, p=None, **taper_kws):
 
 # If we can get it, we want the cythonized version
 try:
-    from _utils import tridisolve
+    from ._utils import tridisolve
 
 # If that doesn't work, we define it here:
 except ImportError:


### PR DESCRIPTION
I was using your library and I found it a little bit slow. Diving into the code, I discovered that line (884) in "utils.py" that was trying to import the cythonized module _utils but was unreachable. I just added the dot before the import and the import was successful. I don't know if the dot is only in my case, (venv virtual environment, VSCode, amd64 Windows) or if it's a general fix but I feel that I had to propose changes