### PR TITLE
ENH: Add aarch64 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,10 +65,10 @@ jobs:
         python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
         # No NumPy wheels on 3.8 aarch64 or musl
         exclude:
-          - python: "cp38"
-            buildplat: [ubuntu-latest, manylinux_aarch64]
-          - python: "cp38"
-            buildplat: [ubuntu-latest, cp38-musllinux_x86_64]
+          - buildplat: [ubuntu-latest, manylinux_aarch64]
+            python: "cp38"
+          - buildplat: [ubuntu-latest, musllinux_x86_64]
+            python: "cp38"
         include:
           # Manylinux and arm64 builds (on native hardware) are cheap, do all in one
           - { buildplat: ["ubuntu-latest", "manylinux_x86_64"], python: "*" }

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,6 +63,10 @@ jobs:
           - [macos-13, macosx_x86_64]  # native Intel hardware
           - [windows-latest, win_amd64]
         python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
+        # No NumPy wheels on 3.8 aarch64
+        exclude:
+          - python: "cp38"
+            buildplat: [ubuntu-latest, manylinux_aarch64]
         include:
           # Manylinux and arm64 builds (on native hardware) are cheap, do all in one
           - { buildplat: ["ubuntu-latest", "manylinux_x86_64"], python: "*" }

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,13 +58,15 @@ jobs:
       fail-fast: false
       matrix:
         buildplat:
-          - [ubuntu-20.04, musllinux_x86_64]
-          - [macos-12, macosx_*]
-          - [windows-2019, win_amd64]
+          - [ubuntu-latest, musllinux_x86_64]
+          - [ubuntu-latest, manylinux_aarch64]
+          - [macos-13, macosx_x86_64]  # native Intel hardware
+          - [windows-latest, win_amd64]
         python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
         include:
-          # Manylinux builds are cheap, do all in one
-          - { buildplat: ["ubuntu-20.04", "manylinux_x86_64"], python: "*" }
+          # Manylinux and arm64 builds (on native hardware) are cheap, do all in one
+          - { buildplat: ["ubuntu-latest", "manylinux_x86_64"], python: "*" }
+          - { buildplat: ["macos-14", "macosx_arm64"], python: "*" }
 
     steps:
       - uses: actions/checkout@v3
@@ -75,6 +77,13 @@ jobs:
 
       - name: Update pip/pipx
         run: pip install --upgrade pip pipx
+
+      # For aarch64 support
+      # https://cibuildwheel.pypa.io/en/stable/faq/#emulation
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+        if: runner.os == 'Linux' && endsWith(matrix.buildplat[1], 'aarch64')
 
       - name: Build wheel(s)
         run: pipx run --spec "cibuildwheel>=2.15" cibuildwheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,10 +63,12 @@ jobs:
           - [macos-13, macosx_x86_64]  # native Intel hardware
           - [windows-latest, win_amd64]
         python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
-        # No NumPy wheels on 3.8 aarch64
+        # No NumPy wheels on 3.8 aarch64 or musl
         exclude:
           - python: "cp38"
             buildplat: [ubuntu-latest, manylinux_aarch64]
+          - python: "cp38"
+            buildplat: [ubuntu-latest, cp38-musllinux_x86_64]
         include:
           # Manylinux and arm64 builds (on native hardware) are cheap, do all in one
           - { buildplat: ["ubuntu-latest", "manylinux_x86_64"], python: "*" }

--- a/doc/examples/multi_taper_spectral_estimation.py
+++ b/doc/examples/multi_taper_spectral_estimation.py
@@ -394,7 +394,7 @@ References
 
 .. [Welch1967] P.D. Welch (1967), The use of the fast fourier transform for the
                estimation of power spectra: a method based on time averaging
-               over short modified periodograms. IEEE Transcations on Audio and
+               over short modified periodograms. IEEE Transactions on Audio and
                Electroacoustics.
 
 .. [Slepian1978] Slepian, D. Prolate spheroidal wave functions, Fourier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,12 @@ include = ["nitime*"]
 write_to = "nitime/_version.py"
 
 [tool.cibuildwheel]
-# Disable PyPy
-skip = "pp*"
+# Disable PyPy, and no NumPy wheels for 3.8 Linux aarch64
+skip = "pp* cp38-*_aarch64"
 
 # 64-bit builds only; 32-bit builds seem pretty niche these days, so
 # don't bother unless someone asks
-archs = ["auto64"]
+archs = ["auto64", "aarch64"]
 
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,go.sum,*.css'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,8 @@ requires = [
   "setuptools",
   "setuptools_scm[toml]>=6.2",
   "cython",
-  # As of numpy 1.25, you can now build against older APIs.
-  # https://numpy.org/doc/stable/release/1.25.0-notes.html
-  "numpy>=1.25; python_version > '3.8'",
+  # Wheels need to be built with NumPy 2.0 to be compatible with 2.0 and 1.x
+  "numpy>=2.0.0rc1,<3; python_version > '3.8'",
   # NEP29-minimum as of Aug 17, 2023 (1.25 doesn't support 3.8)
   "numpy==1.22; python_version == '3.8'",
 ]
@@ -56,8 +55,8 @@ include = ["nitime*"]
 write_to = "nitime/_version.py"
 
 [tool.cibuildwheel]
-# Disable PyPy, and no NumPy wheels for 3.8 Linux aarch64
-skip = "pp* cp38-*_aarch64"
+# Disable PyPy, and no NumPy wheels for 3.8 Linux aarch64 or musl
+skip = "pp* cp38-*_aarch64 cp38-musllinux_*"
 
 # 64-bit builds only; 32-bit builds seem pretty niche these days, so
 # don't bother unless someone asks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ skip = "pp* cp38-*_aarch64"
 
 # 64-bit builds only; 32-bit builds seem pretty niche these days, so
 # don't bother unless someone asks
-archs = ["auto64", "aarch64"]
+archs = ["native"]
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64", "aarch64"]
 
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,go.sum,*.css'


### PR DESCRIPTION
Closes #216 

1. Update OS defs to [-latest in accordance with cibuildwheel docs](https://cibuildwheel.pypa.io/en/stable/setup/#github-actions)...
2. ...Except for `macos`, where you can triage based on native Intel and arm64 hardware now
3. Move arm64 to the "speedy" path used by Linux, I think it might be fast enough but we'll see 🤞 
4. Add aarch64, with separate builds per Python because it will be slow (it uses emulation) 
5. *EDIT: Build against NumPy 2.0*