### PR TITLE
MAINT: Test against latest NumPy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # We test NumPy dev on 3.11
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         requires: ['requirements.txt']
         include:
@@ -37,9 +38,13 @@ jobs:
         allow-prereleases: true
     - name: Install
       run: |
+        set -eo pipefail
         python -m pip install --upgrade pip
         python -m pip install -r ${{ matrix.requires }}
         python -m pip install -r requirements-dev.txt
+        if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
+          python -m pip install --only-binary numpy --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple "numpy>=2.1.0.dev0"
+        fi
         python -m pip install .
     - name: Lint
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         # We test NumPy dev on 3.11

--- a/nitime/algorithms/event_related.py
+++ b/nitime/algorithms/event_related.py
@@ -10,7 +10,7 @@ from nitime.lazy import scipy_fftpack as fftpack
 
 
 def fir(timeseries, design):
-    """
+    r"""
     Calculate the FIR (finite impulse response) HRF, according to [Burock2000]_
 
     Parameters

--- a/nitime/algorithms/tests/test_spectral.py
+++ b/nitime/algorithms/tests/test_spectral.py
@@ -246,8 +246,7 @@ def test_mtm_lin_combo():
         mtm_cross = tsa.mtm_cross_spectrum(
             spec1, spec2, (weights[0], weights[1]), sides=sides
             )
-        npt.assert_(mtm_cross.dtype in np.sctypes['complex'],
-               'Wrong dtype for crossspectrum')
+        assert mtm_cross.dtype == np.complex128, 'Wrong dtype for crossspectrum'
         npt.assert_(len(mtm_cross) == 51,
                'Wrong length for halfband spectrum')
         sides = 'twosided'
@@ -260,8 +259,7 @@ def test_mtm_lin_combo():
         mtm_auto = tsa.mtm_cross_spectrum(
             spec1, spec1, weights[0], sides=sides
             )
-        npt.assert_(mtm_auto.dtype in np.sctypes['float'],
-               'Wrong dtype for autospectrum')
+        assert mtm_auto.dtype == np.float64, 'Wrong dtype for autospectrum'
         npt.assert_(len(mtm_auto) == 51,
                'Wrong length for halfband spectrum')
         sides = 'twosided'

--- a/nitime/index_utils.py
+++ b/nitime/index_utils.py
@@ -6,11 +6,11 @@ __all__ = ['tri', 'triu', 'tril', 'mask_indices', 'tril_indices',
            'tril_indices_from', 'triu_indices', 'triu_indices_from',
            ]
 
-from numpy.core.numeric import asanyarray, subtract, arange, \
+from numpy import asanyarray, subtract, arange, \
      greater_equal, multiply, ones, asarray, where
 
-# Need to import numpy for the doctests! 
-import numpy as np  
+# Need to import numpy for the doctests!
+import numpy as np
 
 def tri(N, M=None, k=0, dtype=float):
     """

--- a/nitime/tests/test_timeseries.py
+++ b/nitime/tests/test_timeseries.py
@@ -925,7 +925,11 @@ def test_timearray_math_functions():
             npt.assert_(getattr(b, f)().__class__ == ts.TimeArray)
             npt.assert_(getattr(b, f)().time_unit == b.time_unit)
             # comparison with unitless should convert to the TimeArray's units
-            npt.assert_(getattr(b, f)() == getattr(a, f)())
+            if f == "ptp":
+                want = np.ptp(a)  # ndarray.ptp removed in 2.0
+            else:
+                want = getattr(a, f)()
+            npt.assert_(getattr(b, f)() == want)
 
 
 def test_timearray_var_prod():

--- a/nitime/tests/test_timeseries.py
+++ b/nitime/tests/test_timeseries.py
@@ -916,20 +916,20 @@ def test_index_int64():
     assert repr(b[0]) == repr(b[np.int32(0)])
 
 
-def test_timearray_math_functions():
+@pytest.mark.parametrize('f', ['min', 'max', 'mean', 'ptp', 'sum'])
+@pytest.mark.parametrize('tu', ['s', 'ms', 'ps', 'D'])
+def test_timearray_math_functions(f, tu):
     "Calling TimeArray.min() .max(), mean() should return TimeArrays"
     a = np.arange(2, 11)
-    for f in ['min', 'max', 'mean', 'ptp', 'sum']:
-        for tu in ['s', 'ms', 'ps', 'D']:
-            b = ts.TimeArray(a, time_unit=tu)
-            npt.assert_(getattr(b, f)().__class__ == ts.TimeArray)
-            npt.assert_(getattr(b, f)().time_unit == b.time_unit)
-            # comparison with unitless should convert to the TimeArray's units
-            if f == "ptp":
-                want = np.ptp(a)  # ndarray.ptp removed in 2.0
-            else:
-                want = getattr(a, f)()
-            npt.assert_(getattr(b, f)() == want)
+    b = ts.TimeArray(a, time_unit=tu)
+    if f == "ptp" and ts._NP_2:
+        with pytest.raises(AttributeError, match='`ptp` was removed'):
+            a.ptp()  # ndarray.ptp removed in 2.0
+        return
+    npt.assert_(getattr(b, f)().__class__ == ts.TimeArray)
+    npt.assert_(getattr(b, f)().time_unit == b.time_unit)
+    # comparison with unitless should convert to the TimeArray's units
+    npt.assert_(getattr(b, f)() == getattr(a, f)())
 
 
 def test_timearray_var_prod():

--- a/nitime/tests/test_timeseries.py
+++ b/nitime/tests/test_timeseries.py
@@ -923,13 +923,13 @@ def test_timearray_math_functions(f, tu):
     a = np.arange(2, 11)
     b = ts.TimeArray(a, time_unit=tu)
     if f == "ptp" and ts._NP_2:
-        with pytest.raises(AttributeError, match='`ptp` was removed'):
-            a.ptp()  # ndarray.ptp removed in 2.0
-        return
+        want = np.ptp(a)
+    else:
+        want = getattr(a, f)()
     npt.assert_(getattr(b, f)().__class__ == ts.TimeArray)
     npt.assert_(getattr(b, f)().time_unit == b.time_unit)
     # comparison with unitless should convert to the TimeArray's units
-    npt.assert_(getattr(b, f)() == getattr(a, f)())
+    npt.assert_(getattr(b, f)() == want)
 
 
 def test_timearray_var_prod():

--- a/nitime/tests/test_utils.py
+++ b/nitime/tests/test_utils.py
@@ -302,9 +302,7 @@ def test_detect_lines_2dmode():
 
     npt.assert_(len(lines)==3, 'Detect lines failed multi-sequence mode')
 
-    consistent1 = (lines[0][0] == lines[1][0]).all() and \
-      (lines[1][0] == lines[2][0]).all()
-    consistent2 = (lines[0][1] == lines[1][1]).all() and \
-      (lines[1][1] == lines[2][1]).all()
-
-    npt.assert_(consistent1 and consistent2, 'Inconsistent results')
+    npt.assert_allclose(lines[0][0], lines[1][0])
+    npt.assert_allclose(lines[0][0], lines[2][0])
+    npt.assert_allclose(lines[0][1], lines[1][1])
+    npt.assert_allclose(lines[0][1], lines[2][1])

--- a/nitime/tests/test_utils.py
+++ b/nitime/tests/test_utils.py
@@ -230,26 +230,27 @@ def test_detect_lines():
     """
     Tests detect_lines utility in the reliable low-SNR scenario.
     """
+    rng = np.random.RandomState(0)
     N = 1000
     fft_pow = int( np.ceil(np.log2(N) + 2) )
     NW = 4
-    lines = np.sort(np.random.randint(100, 2**(fft_pow-4), size=(3,)))
+    lines = np.sort(rng.randint(100, 2**(fft_pow-4), size=(3,)))
     while np.any( np.diff(lines) < 2*NW ):
-        lines = np.sort(np.random.randint(2**(fft_pow-4), size=(3,)))
+        lines = np.sort(rng.randint(2**(fft_pow-4), size=(3,)))
     lines = lines.astype('d')
-    #lines += np.random.randn(3) # displace from grid locations
+    #lines += rng.randn(3) # displace from grid locations
     lines /= 2.0**(fft_pow-2) # ensure they are well separated
 
-    phs = np.random.rand(3) * 2 * np.pi
+    phs = rng.rand(3) * 2 * np.pi
     # amps approximately such that RMS power = 1 +/- N(0,1)
-    amps = np.sqrt(2)/2 + np.abs( np.random.randn(3) )
+    amps = np.sqrt(2)/2 + np.abs( rng.randn(3) )
 
     nz_sig = 0.05
     tx = np.arange(N)
 
     harmonics = amps[:,None]*np.cos( 2*np.pi*tx*lines[:,None] + phs[:,None] )
     harmonic = np.sum(harmonics, axis=0)
-    nz = np.random.randn(N) * nz_sig
+    nz = rng.randn(N) * nz_sig
     sig = harmonic + nz
 
     f, b = utils.detect_lines(sig, (NW, 2*NW), low_bias=True, NFFT=2**fft_pow)
@@ -286,11 +287,13 @@ def test_detect_lines_2dmode():
     Test multi-sequence operation
     """
 
+    rng = np.random.RandomState(0)
+
     N = 1000
 
-    sig = np.cos( 2*np.pi*np.arange(N) * 20./N ) + np.random.randn(N) * .01
+    sig = np.cos( 2*np.pi*np.arange(N) * 20./N ) + rng.randn(N) * .01
 
-    sig2d = np.row_stack( (sig, sig, sig) )
+    sig2d = np.vstack( (sig, sig, sig) )
 
     lines = utils.detect_lines(sig2d, (4, 8), low_bias=True, NFFT=2**12)
 

--- a/nitime/tests/test_utils.py
+++ b/nitime/tests/test_utils.py
@@ -230,27 +230,28 @@ def test_detect_lines():
     """
     Tests detect_lines utility in the reliable low-SNR scenario.
     """
-    rng = np.random.RandomState(0)
+    np.random.seed(0)
+
     N = 1000
     fft_pow = int( np.ceil(np.log2(N) + 2) )
     NW = 4
-    lines = np.sort(rng.randint(100, 2**(fft_pow-4), size=(3,)))
+    lines = np.sort(np.random.randint(100, 2**(fft_pow-4), size=(3,)))
     while np.any( np.diff(lines) < 2*NW ):
-        lines = np.sort(rng.randint(2**(fft_pow-4), size=(3,)))
+        lines = np.sort(np.random.randint(2**(fft_pow-4), size=(3,)))
     lines = lines.astype('d')
-    #lines += rng.randn(3) # displace from grid locations
+    #lines += np.random.randn(3) # displace from grid locations
     lines /= 2.0**(fft_pow-2) # ensure they are well separated
 
-    phs = rng.rand(3) * 2 * np.pi
+    phs = np.random.rand(3) * 2 * np.pi
     # amps approximately such that RMS power = 1 +/- N(0,1)
-    amps = np.sqrt(2)/2 + np.abs( rng.randn(3) )
+    amps = np.sqrt(2)/2 + np.abs( np.random.randn(3) )
 
     nz_sig = 0.05
     tx = np.arange(N)
 
     harmonics = amps[:,None]*np.cos( 2*np.pi*tx*lines[:,None] + phs[:,None] )
     harmonic = np.sum(harmonics, axis=0)
-    nz = rng.randn(N) * nz_sig
+    nz = np.random.randn(N) * nz_sig
     sig = harmonic + nz
 
     f, b = utils.detect_lines(sig, (NW, 2*NW), low_bias=True, NFFT=2**fft_pow)
@@ -287,11 +288,13 @@ def test_detect_lines_2dmode():
     Test multi-sequence operation
     """
 
-    rng = np.random.RandomState(0)
+    # This seed affects not just the signal we generate below, but then also
+    # detect_lines->dpss_windows->tridi_inverse_iteration
+    np.random.seed(0)
 
     N = 1000
 
-    sig = np.cos( 2*np.pi*np.arange(N) * 20./N ) + rng.randn(N) * .01
+    sig = np.cos( 2*np.pi*np.arange(N) * 20./N ) + np.random.randn(N) * .01
 
     sig2d = np.vstack( (sig, sig, sig) )
 

--- a/nitime/timeseries.py
+++ b/nitime/timeseries.py
@@ -33,6 +33,11 @@ import numpy as np
 # Our own
 from nitime import descriptors as desc
 
+try:
+    _NP_2 = int(np.__version__.split(".")[0]) >= 2
+except Exception:
+    _NP_2 = True
+
 #-----------------------------------------------------------------------------
 # Module globals
 #-----------------------------------------------------------------------------
@@ -112,7 +117,9 @@ class TimeArray(np.ndarray, TimeInterface):
             which are SI units of time. Default: 's'
 
         copy : bool, optional
-            Whether to create this instance by  copy of a
+            Whether to create this instance by copy of a. If False,
+            a copy will not be forced but might still be required depending
+            on the data array.
 
         Note
         ----
@@ -309,7 +316,12 @@ class TimeArray(np.ndarray, TimeInterface):
         return ret
 
     def ptp(self, *args, **kwargs):
-        ret = TimeArray(np.ptp(self, *args, **kwargs),
+        if _NP_2:
+            raise AttributeError(
+                "`ptp` was removed from the ndarray class in NumPy 2.0. "
+                "Use np.ptp(arr, ...) instead."
+            )
+        ret = TimeArray(np.ndarray.ptp(self, *args, **kwargs),
                         time_unit=base_unit)
         ret.convert_unit(self.time_unit)
         return ret

--- a/nitime/timeseries.py
+++ b/nitime/timeseries.py
@@ -152,7 +152,7 @@ class TimeArray(np.ndarray, TimeInterface):
                 e_s += 'TimeArray in object, or int64 times, in %s' % base_unit
                 raise ValueError(e_s)
 
-            time = np.array(data, copy=False)
+            time = np.asarray(data)
         else:
             if isinstance(data, TimeInterface):
                 time = data.copy()
@@ -309,7 +309,7 @@ class TimeArray(np.ndarray, TimeInterface):
         return ret
 
     def ptp(self, *args, **kwargs):
-        ret = TimeArray(np.ndarray.ptp(self, *args, **kwargs),
+        ret = TimeArray(np.ptp(self, *args, **kwargs),
                         time_unit=base_unit)
         ret.convert_unit(self.time_unit)
         return ret

--- a/nitime/timeseries.py
+++ b/nitime/timeseries.py
@@ -317,11 +317,10 @@ class TimeArray(np.ndarray, TimeInterface):
 
     def ptp(self, *args, **kwargs):
         if _NP_2:
-            raise AttributeError(
-                "`ptp` was removed from the ndarray class in NumPy 2.0. "
-                "Use np.ptp(arr, ...) instead."
-            )
-        ret = TimeArray(np.ndarray.ptp(self, *args, **kwargs),
+            ptp = np.ptp
+        else:
+            ptp = np.ndarray.ptp
+        ret = TimeArray(ptp(self, *args, **kwargs),
                         time_unit=base_unit)
         ret.convert_unit(self.time_unit)
         return ret

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ test-requires = [
     "pytest",
     "pytest-cov",
 ]
-test-command = "pytest {project}/tests"
+test-command = "pytest {project}/nitime/tests"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,9 @@ archs = ["native"]
 
 test-requires = [
     "pytest",
-    "pytest-cov",
+    "nitime[full]",  # Enable all optional behavior
 ]
-test-command = "pytest {project}/nitime/tests"
+test-command = "pytest -rsx --pyargs nitime"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,12 @@ skip = "pp* cp38-*_aarch64 cp38-musllinux_*"
 # don't bother unless someone asks
 archs = ["native"]
 
+test-requires = [
+    "pytest",
+    "pytest-cov",
+]
+test-command = "pytest {project}/tests"
+
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 sphinx
 pytest
-pytest-cov
 nibabel
 networkx
 tomli; python_version < '3.11'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 sphinx
 pytest
+pytest-cov
 nibabel
 networkx
 tomli; python_version < '3.11'


### PR DESCRIPTION
Should fail because of `sctypes` but let's see what else there is.

In theory this could be a separate run but in practice seems like it should be okay just to tack on to one of the Python version runs for speed.

Closes #218
Closes #219
Closes #221