### PR TITLE
MAINT: Add dependabot and fix outdated action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,7 +46,7 @@ jobs:
         run: pipx run build -s
       - uses: actions/upload-artifact@v4
         with:
-          name: sdist
+          name: source-dist
           path: ./dist/*.tar.gz
 
   build-wheel:
@@ -98,7 +98,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.python == '*' && 'all' || matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
+          name: ${{ matrix.python == '*' && 'all' || matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}-dist
           path: ./wheelhouse/*.whl
 
   test-sdist:
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: sdist
+          name: source-dist
           path: ./dist
       - uses: actions/setup-python@v4
         with:
@@ -130,17 +130,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist/
-          pattern: '*'
+          pattern: '*-dist'
           merge-multiple: true
       - name: Check artifacts
-        run: ls -lR
-      - name: Consolidate and re-check
-        run: |
-          set -eo pipefail
-          ls -lR dist/
-          mv dist/*/*.{tar.gz,whl} dist
-          rmdir dist/*/
-          ls -lR dist/
+        run: ls -lR dist/
       - run: pipx run twine check dist/*
 
   publish:
@@ -154,13 +147,7 @@ jobs:
           path: dist/
           pattern: '*'
           merge-multiple: true
-      - name: Consolidate artifacts
-        run: |
-          set -eo pipefail
-          ls -lR dist/
-          mv dist/*/*.{tar.gz,whl} dist
-          rmdir dist/*/
-          ls -lR dist/
+      - run: ls -lR dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -130,19 +130,23 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist/
+          pattern: '*'
+          merge-multiple: true
       - name: Check artifacts
         run: ls -lR
       - name: Consolidate and re-check
         run: |
+          set -eo pipefail
           mv dist/*/*.{tar.gz,whl} dist
           rmdir dist/*/
-          ls -lR
+          ls -lR dist/
       - run: pipx run twine check dist/*
 
   publish:
     runs-on: ubuntu-latest
     environment: "Package deployment"
     needs: [pre-publish]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -159,4 +163,3 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-python@v3
 
       - name: Update pip/pipx
-        run: pip install --upgrade pip pipx
+        run: python -m pip install --upgrade pip pipx
 
       # For aarch64 support
       # https://cibuildwheel.pypa.io/en/stable/faq/#emulation

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -137,6 +137,7 @@ jobs:
       - name: Consolidate and re-check
         run: |
           set -eo pipefail
+          ls -lR dist/
           mv dist/*/*.{tar.gz,whl} dist
           rmdir dist/*/
           ls -lR dist/
@@ -156,6 +157,7 @@ jobs:
       - name: Consolidate artifacts
         run: |
           set -eo pipefail
+          ls -lR dist/
           mv dist/*/*.{tar.gz,whl} dist
           rmdir dist/*/
           ls -lR dist/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -132,8 +132,7 @@ jobs:
           path: dist/
           pattern: '*-dist'
           merge-multiple: true
-      - name: Check artifacts
-        run: ls -lR dist/
+      - run: ls -lR dist/
       - run: pipx run twine check dist/*
 
   publish:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist/
-          pattern: '*'
+          pattern: '*-dist'
           merge-multiple: true
       - run: ls -lR dist/
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
       - name: Build sdist
         run: pipx run build -s
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: ./dist/*.tar.gz
@@ -96,7 +96,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.python == '*' && 'all' || matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
@@ -106,7 +106,7 @@ jobs:
     needs: [build-sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: sdist
           path: ./dist
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-sdist, build-wheel]
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: dist/
       - name: Check artifacts
@@ -143,16 +143,20 @@ jobs:
     runs-on: ubuntu-latest
     environment: "Package deployment"
     needs: [pre-publish]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: dist/
+          pattern: '*'
+          merge-multiple: true
       - name: Consolidate artifacts
         run: |
+          set -eo pipefail
           mv dist/*/*.{tar.gz,whl} dist
           rmdir dist/*/
+          ls -lR dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
I saw nitime is using artifact actions that will be browned-out soon. Update to v4 and add dependabot monthly to keep other stuff up to date. Once this is merged, it should immediately open a new PR since things like checkout and setup-python are out of date.

~~I also changed the logic in one job so that just the upload step is skipped unless it's time to actually upload. This will allow us to check to make sure the downloaded files are organized properly even in this PR rather than waiting for bad news at release time.~~